### PR TITLE
Add drone for dirb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.swp
 dist
 dist/*.tar.gz
+env/

--- a/bin/drone-dirb
+++ b/bin/drone-dirb
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import os
+import sys
+sys.path.append(os.path.abspath(
+	os.path.join(os.path.dirname(__file__), '..'))
+)
+from optparse import OptionParser
+from lairdrone import api
+from lairdrone import dirb
+
+def main():
+	"""
+	main point of execution
+
+	:return:
+	"""
+
+	usage = "usage: %prog <project_id> <file>"
+	description = "%prog imports dirb files into Lair"
+	parser = OptionParser(usage=usage, description=description,
+							version="%prog 0.0.1")
+
+	(options, args) = parser.parse_args()
+	if len(args) < 2:
+		print parser.get_usage()
+		sys.exit(1)
+
+	project_id, result_resource = args
+	project = dirb.parse(project_id, result_resource)
+
+	# Connect to the database
+	db = api.db_connect()
+	api.save(project, db, dirb.TOOL)
+	sys.exit(0)
+
+if __name__ == '__main__':
+	main()

--- a/lairdrone/api.py
+++ b/lairdrone/api.py
@@ -205,6 +205,24 @@ def save(document, db, tool):
 
             host['os'].extend(os_list)
 
+        # Add web paths
+        if file_host['web']:
+            path_list = []
+            for file_path in file_host['web']:
+                dupe_found = False
+                for db_path in host['web']:
+                    if db_path['path'] == file_path['path'] and \
+                        db_path['path_clean'] == file_path['path_clean'] and \
+                        db_path['port'] == file_path['port'] and \
+                        db_path['response_code'] == file_path['response_code']:
+                        dupe_found = True
+
+                if not dupe_found:
+                    path_list.append(file_path)
+                    host['last_modified_by'] = tool
+
+            host['web'].extend(path_list)
+
         post_md5 = hashlib.md5()
         post_md5.update(str(host))
 

--- a/lairdrone/api.py
+++ b/lairdrone/api.py
@@ -260,6 +260,9 @@ def save(document, db, tool):
 
                 if pre_md5 != post_md5:
                     directory['last_modified_by'] = tool
+                    if not is_known_directory:
+                        id = str(ObjectId())
+                        directory['_id'] = id
                     db.web_directories.save(directory)
 
         # Process each port for the host, checking against known ports

--- a/lairdrone/api.py
+++ b/lairdrone/api.py
@@ -78,6 +78,7 @@ def save(document, db, tool):
     :raise: MissingRequiredSchemaField, ProjectDoesNotExistError
     """
 
+    has_errors = False
     valid_statuses = [lair_models.STATUS_GREY, lair_models.STATUS_BLUE,
                       lair_models.STATUS_GREEN, lair_models.STATUS_ORANGE,
                       lair_models.STATUS_RED]
@@ -228,42 +229,47 @@ def save(document, db, tool):
 
         # Process each web directory for the host, checking against existing dirs
         if 'web_directories' in file_host:
-            for file_directory in file_host['web_directories']:
+            # Check if web directories are supported by the remote Lair server.
+            if 'web_directories' in db.collection_names():
+                for file_directory in file_host['web_directories']:
+                    q = {
+                        'project_id': project['_id'],
+                        'host_id': host['_id'],
+                        'path_clean': file_directory['path_clean'],
+                        'port': file_directory['port'],
+                        'response_code': file_directory['response_code'],
+                    }
+                    directory = db.web_directories.find_one(q)
 
-                q = {
-                    'project_id': project['_id'],
-                    'host_id': host['_id'],
-                    'path_clean': file_directory['path_clean'],
-                    'port': file_directory['port'],
-                    'response_code': file_directory['response_code'],
-                }
-                directory = db.web_directories.find_one(q)
+                    is_known_directory = False
+                    if directory:
+                        is_known_directory = True
+                    else:
+                        directory = copy.deepcopy(lair_models.web_directory_model)
 
-                is_known_directory = False
-                if directory:
-                    is_known_directory = True
-                else:
-                    directory = copy.deepcopy(lair_models.web_directory_model)
+                    pre_md5 = hashlib.md5()
+                    pre_md5.update(str(directory))
 
-                pre_md5 = hashlib.md5()
-                pre_md5.update(str(directory))
+                    directory['project_id'] = project['_id']
+                    directory['host_id'] = host['_id']
+                    directory['path'] = file_directory['path']
+                    directory['path_clean'] = file_directory['path_clean']
+                    directory['port'] = file_directory['port']
+                    directory['response_code'] = file_directory['response_code']
 
-                directory['project_id'] = project['_id']
-                directory['host_id'] = host['_id']
-                directory['path'] = file_directory['path']
-                directory['path_clean'] = file_directory['path_clean']
-                directory['port'] = file_directory['port']
-                directory['response_code'] = file_directory['response_code']
+                    post_md5 = hashlib.md5()
+                    post_md5.update(str(directory))
 
-                post_md5 = hashlib.md5()
-                post_md5.update(str(directory))
-
-                if pre_md5 != post_md5:
-                    directory['last_modified_by'] = tool
-                    if not is_known_directory:
-                        id = str(ObjectId())
-                        directory['_id'] = id
-                    db.web_directories.save(directory)
+                    if pre_md5 != post_md5:
+                        directory['last_modified_by'] = tool
+                        if not is_known_directory:
+                            id = str(ObjectId())
+                            directory['_id'] = id
+                        db.web_directories.save(directory)
+            else:
+                has_errors = True
+                print "[!] Your version of Lair does not support the addition of web directories."
+                print "[!] Please check the Lair project on GitHub for more information (https://github.com/lair-framework/lair)."
 
         # Process each port for the host, checking against known ports
         for file_port in file_host['ports']:
@@ -404,5 +410,8 @@ def save(document, db, tool):
 
     db.projects.save(project)
 
-    print "[+] Processing completed: {0} host(s) processed.".format(
-        str(len(document['hosts'])))
+    if not has_errors:
+        print "[+] Processing completed: {0} host(s) processed.".format(
+            str(len(document['hosts'])))
+    else:
+        print "[!] Could not process this drone's data. See above for any error messages."

--- a/lairdrone/dirb.py
+++ b/lairdrone/dirb.py
@@ -126,7 +126,6 @@ def parse(project, resource):
 		print exception
 
 	host_ip, arguments, extracted_data = extract_data(contents)
-	# from pprint import pprint; import ipdb; ipdb.set_trace()
 
 	# Create the project dictionary which acts as foundation of document
 	project_dict = copy.deepcopy(models.project_model)

--- a/lairdrone/dirb.py
+++ b/lairdrone/dirb.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+import os
+import copy
+import re
+import xml.etree.ElementTree as et
+from urlparse import urlparse
+from lairdrone import drone_models as models
+from lairdrone import helper
+
+TOOL = 'dirb'
+
+def build_clean_path(base_url, path, replace_specials=False):
+	"""Remove the base url value out of a path and optionally replace
+	   any special characters with an underscore character (required to 
+	   build 'path_clean').
+
+	   :param base_url: Base URL
+	   :param path: URI following base URL
+	   :param replace_specials: Optional parameter, replaces any special chars with underscore
+	"""
+	path = path.replace(base_url, '')
+	return re.sub('[^a-zA-Z0-9]', '_', path) if replace_specials else path
+
+def extrapolate_args(contents):
+	"""Well... since the result output for dirb doesn't give the commands used, I'm gonna have to 
+	   do it the hard way! Works backwards from the result output to derive the command line args
+	   used. Heavily dependent on the version in use. If any of these expected values change, the
+	   regex patterns need to also be updated. Not the best, but what are ya gonna do?
+
+	   :param contents: String value of output file
+	"""
+	user_agent_pattern = re.compile('USER_AGENT: (.+)')
+	cookie_pattern = re.compile('COOKIE: (.+)')
+	fine_tuning_pattern = re.compile('OPTION: Fine tunning of NOT_FOUND detection')
+	headers_pattern = re.compile('ADDED_HEADERS:.+\n--\n(.+)\n--')
+	case_sensitivity_pattern = re.compile('OPTION: Using Case-Insensitive Searches')
+	location_pattern = re.compile('OPTION: Printing LOCATION header')
+	not_found_pattern = re.compile('OPTION: Ignoring NOT_FOUND code -> (\d+)')
+	output_file_pattern = re.compile('OUTPUT_FILE: (.+)')
+	proxy_pattern = re.compile('PROXY: (.+)')
+	proxy_auth_pattern = re.compile('PROXY AUTHORIZATION: (.+)')
+	not_recursive_pattern = re.compile('OPTION: Not Recursive')
+	silent_mode_pattern = re.compile('OPTION: Silent Mode')
+	trailing_slash_pattern = re.compile('OPTION: NOT forcing an ending')
+	http_auth_pattern = re.compile('AUTHORIZATION: (.+)')
+	non_existing_pattern = re.compile('OPTION: Show Not Existant Pages')
+	stop_warning_pattern = re.compile('OPTION: Not Stoping on warning message')
+	extension_list_pattern = re.compile('EXTENSIONS_LIST: \((.+)\) \|')
+	extension_file_pattern = re.compile('EXTENSIONS_FILE: (.+)')
+	speed_delay_pattern = re.compile('SPEED_DELAY: (\d+) miliseconds')
+	
+	command_args = []
+	command_args.append('-a %s' % user_agent_pattern.findall(contents)[0] if len(user_agent_pattern.findall(contents)) else None)
+	command_args.append('-c "%s"' % cookie_pattern.findall(contents)[0] if len(cookie_pattern.findall(contents)) else None)
+	command_args.append('-f' if len(fine_tuning_pattern.findall(contents)) else None)
+	command_args.append('-H "%s"' % headers_pattern.findall(contents)[0] if len(headers_pattern.findall(contents)) else None)
+	command_args.append('-i' if len(case_sensitivity_pattern.findall(contents)) else None)
+	command_args.append('-l' if len(location_pattern.findall(contents)) else None)
+	command_args.append('-N %s' % not_found_pattern.findall(contents)[0] if len(not_found_pattern.findall(contents)) else None)
+	command_args.append('-o %s' % output_file_pattern.findall(contents)[0] if len(output_file_pattern.findall(contents)) else None)
+	command_args.append('-p %s' % proxy_pattern.findall(contents)[0] if len(proxy_pattern.findall(contents)) else None)
+	command_args.append('-P %s' % proxy_auth_pattern.findall(contents)[0] if len(proxy_auth_pattern.findall(contents)) else None)
+	command_args.append('-r' if len(not_recursive_pattern.findall(contents)) else None)
+	command_args.append('-S' if len(silent_mode_pattern.findall(contents)) else None)
+	command_args.append('-t' if len(trailing_slash_pattern.findall(contents)) else None)
+	command_args.append('-u %s' % http_auth_pattern.findall(contents)[0] if len(http_auth_pattern.findall(contents)) else None)
+	command_args.append('-v' if len(non_existing_pattern.findall(contents)) else None)
+	command_args.append('-w' if len(stop_warning_pattern.findall(contents)) else None)
+	command_args.append('-X %s' % extension_list_pattern.findall(contents)[0] if len(extension_list_pattern.findall(contents)) else None)
+	command_args.append('-x %s' % extension_file_pattern.findall(contents)[0] if len(extension_file_pattern.findall(contents)) else None)
+	command_args.append('-z %s' % speed_delay_pattern.findall(contents)[0] if len(speed_delay_pattern.findall(contents)) else None)
+
+	return 'dirb %s' % ' '.join(filter(None, command_args))
+
+def extract_data(contents):
+	"""Take the output file contents and parse out the results as well as the commands used.
+
+	:param contents: String value of dirb output file
+	"""
+	base_url_pattern = re.compile('URL_BASE: (.+)(\/)?\n')
+	directory_pattern = re.compile('DIRECTORY: (.+)')
+	file_pattern = re.compile('\+ (.+) \(CODE:(\d{3})')
+
+	arguments = extrapolate_args(contents)
+
+	try:
+		base_url = base_url_pattern.findall(contents)[0]
+
+		# base_url at this point is a tuple, with the 2nd item value 
+		# being the 2nd matched group, so we can disregard that.
+		base_url = base_url[0]
+		parsed_url = urlparse(base_url)
+		port = parsed_url.port if parsed_url.port else 80
+	except Exception as exception:
+		print exception
+
+	directories = [(x, '200') for x in directory_pattern.findall(contents)]
+	files = file_pattern.findall(contents)
+	results = directories + files
+	final_results = []
+	for record in results:
+		final_results.append({
+			'path': build_clean_path(base_url, record[0]),
+			'path_clean': build_clean_path(base_url, record[0], True),
+			'port': port,
+			'response_code': record[1],
+			'flag': False,
+		})
+	return parsed_url.hostname, arguments, final_results
+
+def parse(project, resource):
+	"""Parses a Dirb file and updates the Lair database
+
+	:param project: The project id
+	:param resource: The output file provided by dirb
+	"""
+
+	# Attempt to parse resource as a file or string
+	try:
+		if os.path.isfile(resource):
+			with open(resource, 'r') as fh:
+				contents = fh.read()
+		else:
+			contents = resource
+	except Exception as exception:
+		print exception
+
+	host_ip, arguments, extracted_data = extract_data(contents)
+	# from pprint import pprint; import ipdb; ipdb.set_trace()
+
+	# Create the project dictionary which acts as foundation of document
+	project_dict = copy.deepcopy(models.project_model)
+	project_dict['project_id'] = project
+
+	# Pull the command from the file
+	command_dict = copy.deepcopy(models.command_model)
+	command_dict['tool'] = TOOL
+	command_dict['command'] = arguments
+
+	project_dict['commands'].append(command_dict)
+
+	# Proecess host data
+	host_dict = copy.deepcopy(models.host_model)
+	host_dict['string_addr'] = host_ip
+	host_dict['web'] = extracted_data
+
+	project_dict['hosts'].append(host_dict)
+	return project_dict

--- a/lairdrone/dirb.py
+++ b/lairdrone/dirb.py
@@ -3,7 +3,6 @@
 import os
 import copy
 import re
-import xml.etree.ElementTree as et
 from urlparse import urlparse
 from lairdrone import drone_models as models
 from lairdrone import helper

--- a/lairdrone/dirb.py
+++ b/lairdrone/dirb.py
@@ -142,7 +142,7 @@ def parse(project, resource):
 	# Proecess host data
 	host_dict = copy.deepcopy(models.host_model)
 	host_dict['string_addr'] = host_ip
-	host_dict['web'] = extracted_data
+	host_dict['web_directories'] = extracted_data
 
 	project_dict['hosts'].append(host_dict)
 	return project_dict

--- a/lairdrone/dirb.py
+++ b/lairdrone/dirb.py
@@ -88,7 +88,7 @@ def extract_data(contents):
 
 		# base_url at this point is a tuple, with the 2nd item value 
 		# being the 2nd matched group, so we can disregard that.
-		base_url = base_url[0]
+		base_url = base_url[0] if not base_url[0].endswith('/') else base_url[0][:-1]
 		parsed_url = urlparse(base_url)
 		port = parsed_url.port if parsed_url.port else 80
 	except Exception as exception:

--- a/lairdrone/drone_models.py
+++ b/lairdrone/drone_models.py
@@ -53,6 +53,7 @@ host_model = {
     'string_addr': '',
     'mac_addr': '',
     'hostnames': [],            # Strings
+    'web': [],                  # web_models
     'os': [],                   # os_models
     'alive': True,
     'status': STATUS_UNDETERMINED,
@@ -113,4 +114,12 @@ project_model = {
     'vulnerabilities': [],      # vulnerability_models
     'attacks': [],              # attack_models
     'drone_log': []
+}
+
+web_model = {
+    'path': '',
+    'path_clean': '',
+    'port': '',
+    'response_code': '',
+    'flag': False,
 }

--- a/lairdrone/drone_models.py
+++ b/lairdrone/drone_models.py
@@ -53,7 +53,6 @@ host_model = {
     'string_addr': '',
     'mac_addr': '',
     'hostnames': [],            # Strings
-    'web': [],                  # web_models
     'os': [],                   # os_models
     'alive': True,
     'status': STATUS_UNDETERMINED,
@@ -116,10 +115,11 @@ project_model = {
     'drone_log': []
 }
 
-web_model = {
+web_directory_model = {
     'path': '',
     'path_clean': '',
     'port': '',
     'response_code': '',
+    'last_modified_by': '',
     'flag': False,
 }

--- a/lairdrone/lair_models.py
+++ b/lairdrone/lair_models.py
@@ -57,7 +57,6 @@ host_model = {
     'string_addr': '',
     'mac_addr': '',
     'hostnames': [],            # Strings
-    'web': [],                  # web_models
     'os': [],                   # os_models
     'notes': [],
     'alive': True,
@@ -110,10 +109,13 @@ project_model = {
     'files': []
 }
 
-web_model = {
+web_directory_model = {
+    'project_id': '',
+    'host_id': '',
     'path': '',
     'path_clean': '',
     'port': '',
     'response_code': '',
+    'last_modified_by': '',
     'flag': False,
 }

--- a/lairdrone/lair_models.py
+++ b/lairdrone/lair_models.py
@@ -57,6 +57,7 @@ host_model = {
     'string_addr': '',
     'mac_addr': '',
     'hostnames': [],            # Strings
+    'web': [],                  # web_models
     'os': [],                   # os_models
     'notes': [],
     'alive': True,
@@ -107,4 +108,12 @@ project_model = {
     'drone_log': [],
     'messages': [],             # attack_models
     'files': []
+}
+
+web_model = {
+    'path': '',
+    'path_clean': '',
+    'port': '',
+    'response_code': '',
+    'flag': False,
 }


### PR DESCRIPTION
This drone adds dirb result output into the Web Directories view within Lair. 

As the addition of Web Directories is new, I added the ability to first check the Lair db for the web_directories collection, and if it does not exist, fail gracefully and informs the user that their Lair server does not support Web Directories.